### PR TITLE
support for bat/cmd mining files

### DIFF
--- a/MiningApps.json
+++ b/MiningApps.json
@@ -3,6 +3,7 @@
         "path":  "C:\\Users\\benh\\OneDrive\\Mining\\Monero\\xmr-stak-rx-win64-1.0.5\\xmr-stak-rx.exe"
     },
     {
-        "path":  "C:\\Users\\benh\\OneDrive\\Mining\\Ethereum\\Claymore's Dual Ethereum AMD+NVIDIA GPU Miner v15.0\\EthDcrMiner64.exe"
+        "path":  "C:\\Users\\benh\\OneDrive\\Mining\\Ethereum\\Claymore's Dual Ethereum AMD+NVIDIA GPU Miner v15.0\\EthDcrMiner64.exe",
+		"startcmd": "C:\\Users\\benh\\OneDrive\\Mining\\start_eth_mining.bat"
     }
 ]

--- a/Start-Mining.ps1
+++ b/Start-Mining.ps1
@@ -32,13 +32,17 @@ $busy = $busytest.Running | Where-Object {$_-eq $true} | Select-Object -First 1
 
 if(!$busy){
     Write-Log -LogEventText "Found no MiningProofApps Running so resuming mining"
-    foreach ($path in $MinerPaths.Path){
-        $MiningProcessName = ((Split-Path -Leaf $path) -split ".exe")[0]
+	$MinerPaths | Select-Object -Property path, startcmd | ForEach-Object {
+        $MiningProcessName = ((Split-Path -Leaf $_.path) -split ".exe")[0]
         if($RunningProcs.ProcessName -contains $MiningProcessName ){
             Write-Log -LogEventText "$MiningProcessName Already Running"
         }
-        else{
-            start-process -filepath $path -WorkingDirectory (Split-Path -Parent $path) -Verb runAs
+        else {
+            if ($_.startcmd -ne $null) {
+				start-process -filepath $_.startcmd -WorkingDirectory (Split-Path -Parent $_.startcmd) -Verb runAs
+				} else {
+				start-process -filepath $_.path -WorkingDirectory (Split-Path -Parent $_.path) -Verb runAs
+				}
             Write-Log -LogEventText "Started $MiningProcessName"
         }
     }


### PR DESCRIPTION
Added support in json for bat/cmd file to start mining process, still relies on mining exe path to kill

hey Ben,

i love it. running it now. but to start my eth mining i need to run a bat file with all the hoopla in it, so i've added a property to json and had the powershell use it if it finds it (startcmd) otherwise to just start it as you were based on the exe